### PR TITLE
Support Rails 3.1.3 and fix reference_list missing file

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -25,3 +25,7 @@ By default, teambox-client will connect to the hosted service at https://teambox
 == Examples
 
 See the examples directory.
+
+== Important Notes
+
+No support for Ruby 1.9.3 yet.

--- a/README.rdoc
+++ b/README.rdoc
@@ -15,12 +15,12 @@ First, install the teambox-client gem:
 Now, run "irb -rubygems" and this snippet to get the list of activities:
 
   require 'teambox-client'
-  client = Teambox::Client.new(:auth => {:username => 'frank', :password => 'papapa'})
+  client = Teambox::Client.new(:auth => {:user => 'frank', :password => 'papapa'})
   puts client.activities
 
 By default, teambox-client will connect to the hosted service at https://teambox.com/api/1; optionally you can:
 
-  client = Teambox::Client.new(:base_uri => 'http://teambox.mysite.com/api/1', :auth => {:username => 'frank', :password => 'papapa'})
+  client = Teambox::Client.new(:base_uri => 'http://teambox.mysite.com/api/1', :auth => {:user => 'frank', :password => 'papapa'})
 
 == Examples
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
 
     gem.add_dependency("httparty", "~> 0.7.4")
     gem.add_dependency("oauth2", "~> 0.1.1")
-    gem.add_dependency("json", "~> 1.5.1")
+    gem.add_dependency("json", "~> 1.7.5")
   end
 rescue LoadError
   puts "Jeweler (or a dependency) not available. Install it with: sudo gem install jeweler"

--- a/Rakefile
+++ b/Rakefile
@@ -11,8 +11,8 @@ begin
     gem.homepage    = "http://github.com/teambox/teambox-ruby-client"
     gem.authors     = ["Pablo Villalba", "James Urquhart"]
 
-    gem.add_dependency("httparty", "~> 0.7.4")
-    gem.add_dependency("oauth2", "~> 0.1.1")
+    gem.add_dependency("httparty", "~> 0.9.0")
+    gem.add_dependency("oauth2", "~> 0.8.0")
     gem.add_dependency("json", "~> 1.7.5")
   end
 rescue LoadError

--- a/teambox-client.gemspec
+++ b/teambox-client.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   ]
   s.homepage = %q{http://github.com/teambox/teambox-ruby-client}
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.6.2}
+  s.rubygems_version = %q{1.8.6}
   s.summary = %q{A ruby gem wrapper for Teambox API}
 
   if s.respond_to? :specification_version then

--- a/teambox-client.gemspec
+++ b/teambox-client.gemspec
@@ -65,16 +65,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<httparty>, ["~> 0.7.4"])
       s.add_runtime_dependency(%q<oauth2>, ["~> 0.1.1"])
-      s.add_runtime_dependency(%q<json>, ["~> 1.5.1"])
+      s.add_runtime_dependency(%q<json>, ["~> 1.7.5"])
     else
       s.add_dependency(%q<httparty>, ["~> 0.7.4"])
       s.add_dependency(%q<oauth2>, ["~> 0.1.1"])
-      s.add_dependency(%q<json>, ["~> 1.5.1"])
+      s.add_dependency(%q<json>, ["~> 1.7.5"])
     end
   else
     s.add_dependency(%q<httparty>, ["~> 0.7.4"])
     s.add_dependency(%q<oauth2>, ["~> 0.1.1"])
-    s.add_dependency(%q<json>, ["~> 1.5.1"])
+    s.add_dependency(%q<json>, ["~> 1.7.5"])
   end
 end
 

--- a/teambox-client.gemspec
+++ b/teambox-client.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{teambox-client}
-  s.version = "0.4.0"
+  s.version = "0.4.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Pablo Villalba", "James Urquhart"]
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
     "lib/teambox-client/result_set.rb",
     "lib/teambox-client/teambox.rb",
     "lib/teambox-client/teambox_oauth.rb",
+    "lib/teambox-client/reference_list.rb",    
     "spec/client_spec.rb",
     "spec/conversation_spec.rb",
     "spec/project_spec.rb",
@@ -63,17 +64,17 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httparty>, ["~> 0.7.4"])
-      s.add_runtime_dependency(%q<oauth2>, ["~> 0.1.1"])
+      s.add_runtime_dependency(%q<httparty>, ["~> 0.9.0"])
+      s.add_runtime_dependency(%q<oauth2>, ["~> 0.8.0"])
       s.add_runtime_dependency(%q<json>, ["~> 1.7.5"])
     else
-      s.add_dependency(%q<httparty>, ["~> 0.7.4"])
-      s.add_dependency(%q<oauth2>, ["~> 0.1.1"])
+      s.add_dependency(%q<httparty>, ["~> 0.9.0"])
+      s.add_dependency(%q<oauth2>, ["~> 0.8.0"])
       s.add_dependency(%q<json>, ["~> 1.7.5"])
     end
   else
-    s.add_dependency(%q<httparty>, ["~> 0.7.4"])
-    s.add_dependency(%q<oauth2>, ["~> 0.1.1"])
+    s.add_dependency(%q<httparty>, ["~> 0.9.0"])
+    s.add_dependency(%q<oauth2>, ["~> 0.8.0"])
     s.add_dependency(%q<json>, ["~> 1.7.5"])
   end
 end


### PR DESCRIPTION
Gem hasn't been updated for a while and gave me few problems, starting with Uninitialized Constant Teambox::Client then gem dependency problem.

I basically:
- updated the gem_depedencies
- add missing reference in gemspec to reference_list.rb
- fixed typo in README for client authentication. It should be :user rather than :username. It's correct in the Examples folder

Gem seems to work fine now under Rails 3.1. and Ruby 1.9.2 but not 1.9.3
